### PR TITLE
allow for combination of multiple cookbooks

### DIFF
--- a/bin/coshsh-cook
+++ b/bin/coshsh-cook
@@ -62,9 +62,9 @@ if __name__ == '__main__':
     parser = OptionParser(
         "%prog [options] --cookbook cookbookfile [--recipe recipe]",
         version="%prog " + VERSION)
-    parser.add_option('--cookbook', action='store',
-                      dest="cookbook_file",
-                      help='Config file')
+    parser.add_option('--cookbook', action='append',
+                      dest="cookbook_files",
+                      help='One or more Config files')
     parser.add_option('--recipe', action='store',
                       dest="default_recipe",
                       help="Cook a configuration following <recipe>")
@@ -84,16 +84,16 @@ if __name__ == '__main__':
 
     opts, args = parser.parse_args()
     generator = Generator()
-    if opts.cookbook_file:
-        generator.cookbook = os.path.abspath(opts.cookbook_file)
+    if opts.cookbook_files:
+        generator.cookbook = '___'.join(map(lambda cf: os.path.basename(os.path.abspath(cf)), opts.cookbook_files))
         recipe_configs = {}
         datasource_configs = {}
         datarecipient_configs = {}
         recipes = []
         cookbook = coshsh.configparser.CoshshConfigParser()
-        cookbook.read(opts.cookbook_file)
+        cookbook.read(opts.cookbook_files)
         if cookbook._sections == {}:
-            print "Bad or missing cookbook file : %s " % opts.cookbook_file
+            print "Bad or missing cookbook files : %s " % ', '.join(opts.cookbook_files)
             sys.exit(2)
             
         for ds in [section for section in cookbook.sections() if section.startswith('datarecipient_')]:

--- a/coshsh/generator.py
+++ b/coshsh/generator.py
@@ -50,7 +50,7 @@ class Generator(object):
             except Exception:
                 coshshuser = os.getenv("username")
             hostname = gethostname()
-            cookbook = os.path.basename(self.cookbook)
+            cookbook = self.cookbook
             if self.pg_username:
                 pg_auth_handler = lambda url, method, timeout, headers, data: basic_auth_handler(url, method, timeout, headers, data, self.pg_username, self.pg_password)
             else:

--- a/tests/etc/coshsh6.cfg
+++ b/tests/etc/coshsh6.cfg
@@ -1,0 +1,6 @@
+[recipe_TEST4]
+objects_dir = ./var/objects/test1_mod
+classes_dir = ./recipes/test4/classes
+templates_dir = ./recipes/test4/templates
+datasources = SIMPLESAMPLE
+pid_dir = /tmp

--- a/tests/test_bin.py
+++ b/tests/test_bin.py
@@ -45,6 +45,19 @@ class CoshshTest(unittest.TestCase):
         self.assert_(os.path.exists("var/objects/test1/static/service_templates/os_windows_fs.cfg"))
         self.assert_(os.path.exists("var/objects/test1/static/service_templates/os_windows.cfg"))
 
+    def test_multiple_cookbooks(self):
+        self.print_header()
+        os.makedirs("./var/objects/test1/static")
+        os.makedirs("./var/objects/test1_mod/static")
+        self.assert_(os.path.exists("var/objects/test1/static"))
+        self.assert_(os.path.exists("var/objects/test1_mod/static"))
+        self.assert_(os.path.exists("../bin/coshsh-create-template-tree"))
+        #subprocess.call(["../bin/coshsh-create-template-tree", "--cookbook", "etc/coshsh.cfg", "--recipe", "test4", "--template", "os_windows_fs"], shell=True)
+        subprocess.call("../bin/coshsh-create-template-tree --cookbook etc/coshsh.cfg --cookbook etc/coshsh6.cfg --recipe test4 --template os_windows_fs", shell=True)
+        self.assert_(os.path.exists("var/objects/test1_mod/static/service_templates"))
+        self.assert_(os.path.exists("var/objects/test1_mod/static/service_templates/os_windows_fs.cfg"))
+        self.assert_(os.path.exists("var/objects/test1_mod/static/service_templates/os_windows.cfg"))
+
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This change adds the capability of specifying multiple cookbooks which will add up / overwrite with each other in the order they are specified.

Having this capability allows splitting cookbooks into environment-dependent and environment-independent parts, which makes CI much easier and less error-prone. 

As far as I could see, aside from config parsing, the cookbook argument is only used in one other place where it makes its way into some Prometheus output. This change will not break any existing use of this. However, if multiple cookbooks are specified, the cookbook string in the Prometheus output will be the basenames of all cookbooks, joined by the string '___'